### PR TITLE
Use separate user queues for the reports.

### DIFF
--- a/src/components/reports/Report.vue
+++ b/src/components/reports/Report.vue
@@ -24,8 +24,9 @@
 
   import ReportsHeader from "./header/ReportsHeader.vue";
   import A from "../../constants/actions";
+  import ReportType from "../../constants/reportType";
   import WebsocketSend from "../../contracts/websocketSend";
-  import UnlockSubUnitRequest from "../../contracts/edit/unlockSubUnitRequest";
+  import GetReportRequest from "../../contracts/reports/getReportRequest";
   import WebsocketSubscribe from "../../contracts/websocketSubscribe";
   import WebsocketUnsubscribe from "../../contracts/websocketUnsubscribe";
 
@@ -40,7 +41,7 @@
           A.WEBSOCKET_SEND,
           new WebsocketSend(
             "getEquipmentReport",
-            new UnlockSubUnitRequest("", "")
+            new GetReportRequest(ReportType.EQUIPMENT)
           ),
         );
       },
@@ -49,7 +50,7 @@
           A.WEBSOCKET_SEND,
           new WebsocketSend(
             "getMissionsReport",
-            new UnlockSubUnitRequest("", "")
+           new GetReportRequest(ReportType.MISSIONS)
           )
         );
       }
@@ -79,11 +80,11 @@
         self.$store.dispatch(A.SHOW_PDF_FILE, {'response': response.body, 'fileName': 'Raport misiuni.xlsx'});
       };
       this.$store.dispatch(
-        A.WEBSOCKET_SUBSCRIBE,
+        A.WEBSOCKET_SUBSCRIBE_USER,
         new WebsocketSubscribe("equipmentReport", onEquipmentReportReceived, onError)
       );
       this.$store.dispatch(
-        A.WEBSOCKET_SUBSCRIBE,
+        A.WEBSOCKET_SUBSCRIBE_USER,
         new WebsocketSubscribe("missionsReport", onMissionReportReceived, onError)
       );
 

--- a/src/constants/reportType.js
+++ b/src/constants/reportType.js
@@ -1,0 +1,5 @@
+export default {
+    EQUIPMENT: 'EQUIPMENT',
+    MISSIONS: 'MISSIONS',
+    SERVICES: 'SERVICES'
+}

--- a/src/contracts/reports/getReportRequest.js
+++ b/src/contracts/reports/getReportRequest.js
@@ -1,0 +1,7 @@
+class GetReportRequest {
+  constructor(type) {
+    this.type = type;
+  }
+}
+
+export default GetReportRequest;


### PR DESCRIPTION
The report should be sent only to the requester.